### PR TITLE
Add static accessor for FileTokenReader (OSK-2)

### DIFF
--- a/src/OSK.Parsing.FileTokens/FileTokenParser.cs
+++ b/src/OSK.Parsing.FileTokens/FileTokenParser.cs
@@ -1,0 +1,16 @@
+﻿using OSK.Parsing.FileTokens.Handlers;
+using OSK.Parsing.FileTokens.Internal.Services;
+using OSK.Parsing.FileTokens.Options;
+using OSK.Parsing.FileTokens.Ports;
+
+namespace OSK.Parsing.FileTokens
+{
+    public static class FileTokenParser
+    {
+        public static IFileTokenReader OpenRead(string filePath)
+            => OpenRead(filePath, DefaultTokenStateHandler.Instance);
+
+        public static IFileTokenReader OpenRead(string filePath, ITokenStateHandler tokenStateHandler)
+            => new FileTokenReader(filePath, tokenStateHandler, new FileTokenReaderOptions());
+    }
+}


### PR DESCRIPTION
Motivation
----
There is no way to access the internal implementation for the IFileTokenReader and thus this library is useless

Modifications
----
* Added simple static accessor that will create the FileTokenReader for consumers

Result
----
FileTokenReader is now usable

Fixes #2