### PR TITLE
Update FileToken Constructor (OSK-5)

### DIFF
--- a/src/OSK.Parsing.FileTokens/Models/FileToken.cs
+++ b/src/OSK.Parsing.FileTokens/Models/FileToken.cs
@@ -15,7 +15,7 @@ namespace OSK.Parsing.FileTokens.Models
 
         #region Constructors
 
-        internal FileToken(FileTokenType tokenType, params int[] rawValue)
+        public FileToken(FileTokenType tokenType, params int[] rawValue)
         {
             TokenType = tokenType;
             RawTokens = rawValue ?? throw new ArgumentNullException(nameof(rawValue));


### PR DESCRIPTION
Motivation
----
The constructor for the file token model object is internal and causing issues with consumers of the library

Modifications
----
* changed the visibility of the constructor to be public

Result
----
The constructor can now be used by consumers

Fixes #5