### PR TITLE
Fix parsing issues (OSK-7)

### DIFF
--- a/src/OSK.Parsing.FileTokens.UnitTests/GenericTokenHandlerTests.cs
+++ b/src/OSK.Parsing.FileTokens.UnitTests/GenericTokenHandlerTests.cs
@@ -225,12 +225,12 @@ namespace OSK.Parsing.FileTokens.UnitTests
             Assert.Equal(TokenReadState.ReadNext, result.ReadState);
             Assert.Null(result.EndToken);
             Assert.Equal(0, result.TokenIndex);
-            Assert.Single(result.Tokens);
-            Assert.Equal(tokenValue, result.Tokens[0]);
+            Assert.Equal(2, result.Tokens.Length);
+            Assert.Equal((int[])[tokenValue, tokenValue], result.Tokens);
         }
 
         [Fact]
-        public void GetNextTokenState_TextTokenState_FallsBackToInitialMethod_InvalidText()
+        public void GetNextTokenState_TextTokenState_FallsBackToInitialMethod_ReturnsTextTokenWithEndState()
         {
             // Arrange
             var tokenValue = 999;
@@ -239,8 +239,8 @@ namespace OSK.Parsing.FileTokens.UnitTests
             var result = _tokenHandler.GetNextTokenState(new TokenState(FileTokenType.Text, TokenReadState.ReadNext, tokenValue), tokenValue);
 
             // Assert
-            Assert.Equal(FileTokenType.Ignore, result.TokenType);
-            Assert.Equal(TokenReadState.SingleRead, result.ReadState);
+            Assert.Equal(FileTokenType.Text, result.TokenType);
+            Assert.Equal(TokenReadState.EndRead, result.ReadState);
             Assert.Null(result.EndToken);
             Assert.Equal(0, result.TokenIndex);
             Assert.Single(result.Tokens);

--- a/src/OSK.Parsing.FileTokens.UnitTests/Internal/Services/FileTokenReaderTests.cs
+++ b/src/OSK.Parsing.FileTokens.UnitTests/Internal/Services/FileTokenReaderTests.cs
@@ -247,12 +247,11 @@ namespace OSK.Parsing.FileTokens.UnitTests.Internal.Services
                 .Returns(tokens[0]);
 
             var i = 1;
-            var finalTokenState = new TokenState(FileTokenType.Delimeter, TokenReadState.EndRead, 54321);
             _tokenStateHandlerMock.Setup(m => m.GetNextTokenState(It.IsAny<TokenState>(), It.IsAny<int>()))
                 .Returns((TokenState state, int _) =>
                 {
                     var tokenState = i == tokens.Length
-                       ? finalTokenState
+                       ? new TokenState(FileTokenType.Text, TokenReadState.EndRead, state.Tokens)
                        : new TokenState(FileTokenType.Text, TokenReadState.ReadNext, state.Tokens.Append(1).ToArray());
                     i++;
                     return tokenState;

--- a/src/OSK.Parsing.FileTokens/GenericTokenStateHandler.cs
+++ b/src/OSK.Parsing.FileTokens/GenericTokenStateHandler.cs
@@ -51,8 +51,15 @@ namespace OSK.Parsing.FileTokens
             }
             if (previousState.TokenType == FileTokenType.Text)
             {
-                return GetInitialTokenState(character, 0);
-            }
+                var nextTokenState = GetInitialTokenState(character, 0);
+                var stateChanged = nextTokenState.TokenType != FileTokenType.Text;
+                var characters = stateChanged
+                    ? previousState.Tokens
+                    : previousState.Tokens.Append(character).ToArray();
+                return stateChanged
+                    ? new TokenState(FileTokenType.Text, TokenReadState.EndRead, characters)
+                    : new TokenState(FileTokenType.Text, TokenReadState.ReadNext, characters);
+            } 
             if (previousState.ReadState == TokenReadState.Reset)
             {
                 return GetInitialTokenState(character, previousState.TokenIndex + 1);

--- a/src/OSK.Parsing.FileTokens/Handlers/DefaultTokenStateHandler.cs
+++ b/src/OSK.Parsing.FileTokens/Handlers/DefaultTokenStateHandler.cs
@@ -1,4 +1,6 @@
 ﻿using OSK.Parsing.FileTokens.Models;
+using System;
+using System.Linq;
 
 namespace OSK.Parsing.FileTokens.Handlers
 {
@@ -39,14 +41,21 @@ namespace OSK.Parsing.FileTokens.Handlers
             new SingleReadToken(FileTokenType.Delimeter, Colon),
             new SingleReadToken(FileTokenType.Delimeter, Tab),
             new SingleReadToken(FileTokenType.Separator, Comma),
+            new SingleReadToken(FileTokenType.NewLine, NewLine),
+            new SingleReadToken(FileTokenType.ClosureStart, OpenParentheses),
+            new SingleReadToken(FileTokenType.ClosureEnd, CloseParentheses),
+            new SingleReadToken(FileTokenType.ClosureStart, OpenBracket),
+            new SingleReadToken(FileTokenType.ClosureEnd, CloseBracket)
         };
 
         private static MultiReadToken[] MultiTokens => new[]
         {
-            new MultiReadToken(new SingleReadToken(FileTokenType.ClosureStart, OpenParentheses),
-                new SingleReadToken(FileTokenType.ClosureEnd, CloseParentheses)),
-            new MultiReadToken(new SingleReadToken(FileTokenType.ClosureStart, OpenBracket),
-                new SingleReadToken(FileTokenType.ClosureEnd, CloseBracket))
+            new MultiReadToken(new SingleReadToken(FileTokenType.Comment, Slash, Slash),
+                new SingleReadToken(FileTokenType.NewLine, Environment.NewLine.Select(c => (int)c).ToArray())),
+            new MultiReadToken(new SingleReadToken(FileTokenType.Comment, Slash, Asterisk),
+                new SingleReadToken(FileTokenType.Comment, Asterisk, Slash)),
+            new MultiReadToken(new SingleReadToken(FileTokenType.NewLine, CarriageReturn), 
+                new SingleReadToken(FileTokenType.NewLine, NewLine))
         };
 
         #endregion

--- a/src/OSK.Parsing.FileTokens/Internal/Services/FileTokenReader.cs
+++ b/src/OSK.Parsing.FileTokens/Internal/Services/FileTokenReader.cs
@@ -109,13 +109,6 @@ namespace OSK.Parsing.FileTokens.Internal.Services
                     ? _tokenStateHandler.GetInitialTokenState(fileByte)
                     : _tokenStateHandler.GetNextTokenState(previousTokenState, fileByte);
 
-                if (previousTokenState != null && previousTokenState.TokenType == FileTokenType.Text 
-                     && tokenState.TokenType != FileTokenType.Text)
-                {
-                    _fileStream.Position--;
-                    return new TokenState(previousTokenState.TokenType, TokenReadState.EndRead, previousTokenState.Tokens); ;
-                }
-
                 switch (tokenState.ReadState)
                 {
                     case TokenReadState.SingleRead:
@@ -123,6 +116,10 @@ namespace OSK.Parsing.FileTokens.Internal.Services
                         if (tokenState.TokenType == FileTokenType.Ignore)
                         {
                             continue;
+                        }
+                        if (tokenState.TokenType == FileTokenType.Text)
+                        {
+                            _fileStream.Position--;
                         }
                         return tokenState;
                     case TokenReadState.ReadNext:


### PR DESCRIPTION
Motivation
----
Some issues arose when the token reader was used to parse text and delimeter file tokens

Modifications
----
* Updated the GenericTokenStateHandler/FileTokenReader to better handle state with text file tokens
* Updated DefaultTokenStateHandler to account for comments/delimeters/etc. as expected

Result
----
Text, delimeter, and other token isses should be fixed with DefaultTokenStateHandler

Fixes #7